### PR TITLE
Fix for Op in tf 1.11 that should be ignored

### DIFF
--- a/cmd/graphpipe-tf/main.go
+++ b/cmd/graphpipe-tf/main.go
@@ -185,7 +185,7 @@ func initializeMetadata(opts options, c *tfContext) *graphpipe.NativeMetadataRes
 			}
 			c.shapes = append(c.shapes, shape)
 
-			if op.Type() != "Const" && t != graphpipefb.TypeNull {
+			if op.Type() != "Const" && op.Type() != "CheckNumerics" && t != graphpipefb.TypeNull {
 				if len(node.Input) == 0 {
 					c.defaultInputs = append(c.defaultInputs, name)
 				} else if _, present := outputsThatAreInputs[node.Name]; !present {


### PR DESCRIPTION
CheckNumerics should not be considered for default inputs or outputs